### PR TITLE
Add aria roles, labels, state and tab index to inaccessible items

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -346,7 +346,7 @@
               {#if showCollectionSelect}
                 <CollectionSelector selected={$selectedCollection} />
                 {#if smallScreen}
-                  <span on:click={closeNavInput}
+                  <span role="button" aria-label="Close collection list" on:click={closeNavInput}
                     ><CloseIcon size="1.6rem" /></span
                   >
                 {/if}
@@ -362,7 +362,7 @@
                   use:gainFocus
                 />
                 {#if smallScreen}
-                  <span on:click={closeNavInput}
+                  <span role="button" aria-label="Close search" on:click={closeNavInput}
                     ><CloseIcon size="1.6rem" /></span
                   >
                 {/if}
@@ -371,26 +371,26 @@
           </li>
           <li class="icons">
             {#if !showCollectionSelect && !showSearch && smallScreen}
-              <span on:click={toggleCollectionsSelect}
+              <span role="button" aria-label="Open collection list" on:click={toggleCollectionsSelect}
                 ><CollectionsIcon size="1.5rem" /></span
               >
-              <span on:click={toggleSearch}><SearchIcon size="1.5rem" /></span>
+              <span role="button" aria-label="Open search" on:click={toggleSearch}><SearchIcon size="1.5rem" /></span>
             {/if}
             {#if (!showCollectionSelect && !showSearch) || !smallScreen}
               {#if $pendingDownloads > 0}
-                <span on:click={showDownloadDialog} class="withText">
+                <span role="button" aria-label="Show downloads" on:click={showDownloadDialog} class="withText">
                   <DownloadIcon size="1.5rem" />
                   {$pendingDownloads}
                 </span>
               {/if}
 
               {#if sleepTime > 0}
-                <span on:click={stopSleepTimer} class="withText">
+                <span role="button" aria-label="Stop sleep timer" on:click={stopSleepTimer} class="withText">
                   <SleepCancelIcon size="1.5rem" />
                   {sleepTime}
                 </span>
               {:else}
-                <span on:click={startSleepTimer}>
+                <span role="button" aria-label="Start sleep timer" on:click={startSleepTimer}>
                   <SleepIcon size="1.5rem" />
                 </span>
               {/if}

--- a/src/components/FileItem.svelte
+++ b/src/components/FileItem.svelte
@@ -54,9 +54,9 @@
 </script>
 
 <div bind:this={elem} class="item" class:active={isPlaying}>
-  {#if isPlaying}<div><Play size="2rem" /></div>{/if}
+  {#if isPlaying}<div aria-label="Now playing"><Play size="2rem" /></div>{/if}
   <div class="info">
-    <h4 class="file-name">{baseName}</h4>
+    <h4 class="file-name" role="button">{baseName}</h4>
     {#if title}
       <h6 class="title">{title}</h6>
     {/if}

--- a/src/components/Player.svelte
+++ b/src/components/Player.svelte
@@ -666,7 +666,7 @@
 </script>
 
 <div class="player-separator">
-  <div class="player-expand-button" on:click={() => (expanded = !expanded)}>
+  <div tabindex="0" role="button" aria-label="Volume and speed controls" aria-expanded={expanded} class="player-expand-button" on:click={() => (expanded = !expanded)}>
     {#if expanded}<CollapsIcon size="48px" />{:else}<ExpandIcon
         size="48px"
       />{/if}
@@ -676,14 +676,16 @@
 {#if expanded}
   <div class="extra-controls">
     <div class="volume-control slider-control extra-control">
-      <span><VolumeIcon size={fileIconSize} /></span>
+      <span ><VolumeIcon size={fileIconSize} /></span>
       <input
+        tabindex="0"
         type="range"
         name="volume"
         id="volume"
         min="0"
         max="1"
         step="0.01"
+        aria-label="Volume"
         bind:value={volume}
       />
       <span class="control-value">{volume.toFixed(2)}</span>
@@ -692,12 +694,14 @@
     <div class="speed-control slider-control extra-control">
       <span><SpeedIcon size={fileIconSize} /></span>
       <input
+        tabindex="0"
         type="range"
         name="playback-speed"
         id="playback-speed"
         min="0.5"
         max="3"
         step="0.1"
+        aria-label="Speed"
         bind:value={playbackRate}
       />
       <span class="control-value">{playbackRate.toFixed(1)}</span>
@@ -711,6 +715,7 @@
       ><FolderIcon size={fileIconSize} /></label
     >
     <span
+      role="link"
       id="folder-name"
       class="item-name clickable"
       dir="rtl"
@@ -739,7 +744,7 @@
         >{folderSize}</span
       >)
     </span>
-    <span id="file-name" class="item-name clickable" on:click={locateFile}>
+    <span role="link" id="file-name" class="item-name clickable" on:click={locateFile}>
       {fileDisplayName}
     </span>
   </div>
@@ -770,6 +775,7 @@
         bind:value={progressValue}
         on:mousedown={handleProgressMouseDown}
         on:touchstart={handleProgressMouseDown}
+        aria-label="Position"
       />
       <CacheIndicator ranges={buffered} totalTime={expectedDuration} />
     </div>
@@ -780,16 +786,19 @@
 </div>
 <div class="controls-bar">
   <div class="player-controls">
-    <span class="control-button" on:click={playPrevious}>
+    <span tabindex="0" role="button" aria-label="Previous" class="control-button" on:click={playPrevious}>
       <PreviousIcon size={controlSize} />
     </span>
-    <span
+    <span tabindex="0" role="button" aria-label="Jump back"
       class="control-button"
       on:click={jumpTimeRelative(-$config.jumpBackTime)}
     >
       <RewindIcon size={controlSize} />
     </span>
     <span
+      tabindex="0"
+      role="button"
+      aria-label={paused ? "Play" : "Pause"}
       class="control-button"
       class:blink={preparingPlayback}
       on:click={playPause}
@@ -800,18 +809,18 @@
         <PauseIcon size={controlSize} />
       {/if}
     </span>
-    <span
+    <span tabindex="0" role="button" aria-label="Jump ahead"
       class="control-button"
       on:click={jumpTimeRelative($config.jumpForwardTime)}
     >
       <ForwardIcon size={controlSize} />
     </span>
-    <span class="control-button" on:click={playNext}>
+    <span tabindex="0" role="button" aria-label="Next" class="control-button" on:click={playNext}>
       <NextIcon size={controlSize} />
     </span>
 
     <!-- <span class="control-button" on:click={null}>
-    <SpeedIcon size="{controlSize}" />
+    <span><SpeedIcon size="{controlSize}" /></span>
   </span> -->
   </div>
 </div>


### PR DESCRIPTION
If I'm opening this pull request wrongly, such as wrong branch, please let me know and I'll fix it.
Also, please test these changes to check if I haven't messed up the formatting (I'm blind and thus can't verify if I have).

I've added the button roles to the relevant spans, added labels for screen readers, set expanded role on toggles, and tab index to let you easily tab from control to control.

Ideally, you should be using the relevant HTMl tags. <button> for buttons for example. Make sure they have relevant text for screen reader accessibility. There were a lot of spans which just included an icon and the screen reader completely skipped over them, so we didn't even know there was a button there at all. For example, the sleep timer buttons.

From my testing, they now show up properly for screen readers. If the buttons were actual buttons, space or enter should activate them. They are not however, so right now, to activate a button like the play, previous and next buttons, the screen readers custom button features have to be used as they conflict with the global hotkeys. There is functionality to disable hotkeys if an element is focused that requires keyboard input, but since everything in this app is made out of spans, including the buttons, I would have had to change this logic quite a lot which I wasn't willing to do without discussing it first.