### PR TITLE
Further ARIA improvements

### DIFF
--- a/src/components/Browser.svelte
+++ b/src/components/Browser.svelte
@@ -376,6 +376,8 @@
           <span
             class="summary-icons"
             on:click|stopPropagation|preventDefault={toggleSubfoldersSort}
+            aria-label="Sort by {sortTime?'Time':'Name'}"
+            role="button"
           >
             {#if sortTime}
               <SortTimeIcon />
@@ -408,7 +410,7 @@
           >
           {#if $collections && $collections.folderDownload}
             <a href={generateDownloadPath()} target="_self"
-              ><span class="summary-icons"><DownloadFolderIcon /></span></a
+              ><span class="summary-icons" aria-label="Download"><DownloadFolderIcon /></span></a
             >
           {/if}
         </summary>

--- a/src/components/ClosableTitle.svelte
+++ b/src/components/ClosableTitle.svelte
@@ -8,7 +8,7 @@
 <!-- svelte-ignore a11y-missing-content -->
 <h2>
   <span><slot /></span>
-  <a href="#close" class="close" on:click|preventDefault={close} />
+  <a href="#close" class="close" on:click|preventDefault={close} aria-label="Close" />
 </h2>
 
 <style>

--- a/src/components/Login.svelte
+++ b/src/components/Login.svelte
@@ -57,9 +57,9 @@ import { getContext } from 'svelte';
     {/if}
     <form on:submit|preventDefault="{login}">
         <label for="shared-secret">Shared Secret</label>
-        <input type="password" name="shared-secret" bind:value="{sharedSecret}">
+        <input type="password" name="shared-secret" id="shared-secret" bind:value="{sharedSecret}">
         <label for="playback-group">Playback Group</label>
-        <input type="text" name="playback-group" bind:value="{playbackGroup}">
+        <input type="text" name="playback-group" id="playback-group" bind:value="{playbackGroup}">
         <button id="login-button">Log in</button>
     </form>
 </div>

--- a/src/components/Player.svelte
+++ b/src/components/Player.svelte
@@ -677,7 +677,7 @@
   <div
     tabindex="0"
     role="button"
-    aria-label="Volume and speed controls"
+    aria-label="More Controls"
     aria-expanded={expanded}
     class="player-expand-button button-like"
     on:click={() => (expanded = !expanded)}


### PR DESCRIPTION
* Adds a button role and label for the *sort* button
* Makes the *download* link visible by adding an ARIA label
* Labels the *close* element, e.g. for the recently listened popup
* Adds an *id* attribute to the *Shared Secret* and the *Playback Group* fields on the login page, so that the labels can work properly
* Changes the label for the *more controls* button, because extra controls other than speed and volume might be added later on